### PR TITLE
Refine analysis tab handling and add syntax tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/index.html
+++ b/index.html
@@ -263,11 +263,12 @@
                 else if (tabName === 'network') renderNetwork(article, analysisContent);
                 else if (tabName === 'sentiment') renderSentiment(article, analysisContent);
             }
-            document.querySelectorAll('.control-btn').forEach(btn => {
-                btn.addEventListener('click', e => {
-                    document.querySelectorAll('.control-btn').forEach(b => b.classList.remove('active'));
-                    e.target.classList.add('active');
-                    switchTab(e.target.dataset.tab);
+            const tabButtons = analysisPanel.querySelectorAll('.control-btn[data-tab]');
+            tabButtons.forEach(btn => {
+                btn.addEventListener('click', () => {
+                    tabButtons.forEach(b => b.classList.remove('active'));
+                    btn.classList.add('active');
+                    switchTab(btn.dataset.tab);
                 });
             });
             switchTab('analysis');

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "ib",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "node test.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/test.js
+++ b/test.js
@@ -1,0 +1,19 @@
+const fs = require('fs');
+
+const html = fs.readFileSync('index.html', 'utf8');
+const scripts = [];
+const regex = /<script\b(?![^>]*\bsrc=)[^>]*>([\s\S]*?)<\/script>/gi;
+let match;
+while ((match = regex.exec(html)) !== null) {
+  scripts.push(match[1]);
+}
+
+try {
+  scripts.forEach((code, idx) => {
+    new Function(code);
+  });
+  console.log('Syntax check passed');
+} catch (err) {
+  console.error('Syntax error in script:', err.message);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- Scope analysis tab handlers to prevent interference with other control buttons
- Add basic Node-based syntax test harness
- Include Node project metadata and ignore node_modules

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e931112c48328a888a35de1b36f86