### PR TITLE
feat: add data ingestion modules

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,7 +95,10 @@
                     <button class="control-btn active font-semibold py-1 px-3" data-sort="relevance">Most Relevant</button>
                     <button class="control-btn font-semibold py-1 px-3" data-sort="time">Latest</button>
                 </div>
-                <button id="export-btn" class="control-btn font-semibold py-1 px-3 text-sm flex items-center gap-1"><i class="ph ph-download-simple"></i> Export SITREP</button>
+                <div class="flex gap-2">
+                    <button id="refresh-btn" class="control-btn font-semibold py-1 px-3 text-sm flex items-center gap-1"><i class="ph ph-arrows-clockwise"></i> Refresh</button>
+                    <button id="export-btn" class="control-btn font-semibold py-1 px-3 text-sm flex items-center gap-1"><i class="ph ph-download-simple"></i> Export SITREP</button>
+                </div>
             </div>
 
             <main id="priority-feed" class="flex-grow space-y-4 overflow-y-auto pr-2"></main>
@@ -107,6 +110,7 @@
     
     <div id="modal-container"></div>
 
+    <script type="module" src="src/data/index.js"></script>
     <script>
     document.addEventListener('DOMContentLoaded', () => {
         const priorityFeed = document.getElementById('priority-feed');
@@ -115,6 +119,7 @@
         const rfiInput = document.getElementById('rfi-search-input');
         const rfiBtn = document.getElementById('rfi-search-btn');
         const exportBtn = document.getElementById('export-btn');
+        const refreshBtn = document.getElementById('refresh-btn');
         const settingsBtn = document.getElementById('settings-btn');
         const modalContainer = document.getElementById('modal-container');
 
@@ -400,12 +405,26 @@
         rfiBtn.addEventListener('click', handleRfiSearch);
         rfiInput.addEventListener('keypress', (e) => { if (e.key === 'Enter') handleRfiSearch(); });
         exportBtn.addEventListener('click', handleExport);
+        refreshBtn.addEventListener('click', async () => {
+            refreshBtn.disabled = true;
+            await window.dataModule.refreshData();
+            masterNewsData = await window.dataModule.loadStoredItems();
+            displayedArticles = masterNewsData.slice(0, articlesPerPage);
+            renderPriorityFeed();
+            renderStandbyPanel();
+            refreshBtn.disabled = false;
+        });
         settingsBtn.addEventListener('click', handleSettings);
 
         // Initial Load
-        displayedArticles = masterNewsData.slice(0, articlesPerPage);
-        renderPriorityFeed();
-        renderStandbyPanel();
+        window.dataModule.loadStoredItems().then(items => {
+            if (items.length) {
+                masterNewsData = items.sort((a,b) => b.timestamp - a.timestamp);
+            }
+            displayedArticles = masterNewsData.slice(0, articlesPerPage);
+            renderPriorityFeed();
+            renderStandbyPanel();
+        });
 
         // Auto-update interval
         setInterval(checkForNewArticle, 15000);

--- a/package.json
+++ b/package.json
@@ -9,5 +9,5 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs"
+  "type": "module"
 }

--- a/src/data/api.js
+++ b/src/data/api.js
@@ -1,0 +1,21 @@
+export async function fetchNewsApi(urls = []) {
+  const allItems = [];
+  for (const url of urls) {
+    try {
+      const res = await fetch(url);
+      const data = await res.json();
+      const articles = data.articles || [];
+      articles.forEach(a => {
+        allItems.push({
+          title: a.title || '',
+          content: a.description || '',
+          source: a.source?.name || url,
+          timestamp: a.publishedAt
+        });
+      });
+    } catch (err) {
+      console.error('API fetch failed', err);
+    }
+  }
+  return allItems;
+}

--- a/src/data/index.js
+++ b/src/data/index.js
@@ -1,0 +1,43 @@
+import { fetchRSS } from './rss.js';
+import { fetchNewsApi } from './api.js';
+import { ingestDocuments } from './upload.js';
+import { saveItems, getAllItems, clearItems } from './store.js';
+
+function generateId() {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  return Math.random().toString(36).slice(2);
+}
+
+export function normalize(item) {
+  return {
+    id: item.id || generateId(),
+    title: item.title || '',
+    content: item.content || '',
+    source: item.source || '',
+    timestamp: item.timestamp ? new Date(item.timestamp).toISOString() : new Date().toISOString()
+  };
+}
+
+export async function refreshData(options = {}) {
+  const { rssUrls = [], apiUrls = [], documents = [] } = options;
+  const rssItems = await fetchRSS(rssUrls);
+  const apiItems = await fetchNewsApi(apiUrls);
+  const docItems = ingestDocuments(documents);
+  const items = [...rssItems, ...apiItems, ...docItems].map(normalize);
+  if (items.length) {
+    await clearItems();
+    await saveItems(items);
+  }
+  return items;
+}
+
+export async function loadStoredItems() {
+  const items = await getAllItems();
+  return items.map(i => ({ ...i, timestamp: new Date(i.timestamp) }));
+}
+
+if (typeof window !== 'undefined') {
+  window.dataModule = { refreshData, loadStoredItems };
+}

--- a/src/data/rss.js
+++ b/src/data/rss.js
@@ -1,0 +1,21 @@
+export async function fetchRSS(urls = []) {
+  const allItems = [];
+  for (const url of urls) {
+    try {
+      const res = await fetch(url);
+      const text = await res.text();
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(text, 'application/xml');
+      const items = Array.from(doc.querySelectorAll('item')).map(it => ({
+        title: it.querySelector('title')?.textContent || '',
+        content: it.querySelector('description')?.textContent || '',
+        source: url,
+        timestamp: it.querySelector('pubDate')?.textContent
+      }));
+      allItems.push(...items);
+    } catch (err) {
+      console.error('RSS fetch failed', err);
+    }
+  }
+  return allItems;
+}

--- a/src/data/store.js
+++ b/src/data/store.js
@@ -1,0 +1,66 @@
+const DB_NAME = 'news-db';
+const STORE_NAME = 'items';
+let memoryStore = [];
+
+function isIndexedDBAvailable() {
+  try {
+    return typeof indexedDB !== 'undefined';
+  } catch {
+    return false;
+  }
+}
+
+function openDB() {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, 1);
+    request.onupgradeneeded = () => {
+      request.result.createObjectStore(STORE_NAME, { keyPath: 'id' });
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+export async function saveItems(items) {
+  if (!isIndexedDBAvailable()) {
+    memoryStore.push(...items);
+    return;
+  }
+  const db = await openDB();
+  const tx = db.transaction(STORE_NAME, 'readwrite');
+  const store = tx.objectStore(STORE_NAME);
+  items.forEach(item => store.put(item));
+  return new Promise((resolve, reject) => {
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+export async function getAllItems() {
+  if (!isIndexedDBAvailable()) {
+    return memoryStore;
+  }
+  const db = await openDB();
+  const tx = db.transaction(STORE_NAME, 'readonly');
+  const store = tx.objectStore(STORE_NAME);
+  const request = store.getAll();
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result || []);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+export async function clearItems() {
+  if (!isIndexedDBAvailable()) {
+    memoryStore = [];
+    return;
+  }
+  const db = await openDB();
+  const tx = db.transaction(STORE_NAME, 'readwrite');
+  const store = tx.objectStore(STORE_NAME);
+  store.clear();
+  return new Promise((resolve, reject) => {
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}

--- a/src/data/upload.js
+++ b/src/data/upload.js
@@ -1,0 +1,8 @@
+export function ingestDocuments(files = []) {
+  return files.map(file => ({
+    title: file.name || 'Document',
+    content: file.text || '',
+    source: 'upload',
+    timestamp: Date.now()
+  }));
+}

--- a/test.js
+++ b/test.js
@@ -1,5 +1,8 @@
-const fs = require('fs');
+import fs from 'fs';
+import { saveItems, getAllItems, clearItems } from './src/data/store.js';
+import { normalize } from './src/data/index.js';
 
+// Syntax check for inline scripts in index.html
 const html = fs.readFileSync('index.html', 'utf8');
 const scripts = [];
 const regex = /<script\b(?![^>]*\bsrc=)[^>]*>([\s\S]*?)<\/script>/gi;
@@ -7,9 +10,8 @@ let match;
 while ((match = regex.exec(html)) !== null) {
   scripts.push(match[1]);
 }
-
 try {
-  scripts.forEach((code, idx) => {
+  scripts.forEach(code => {
     new Function(code);
   });
   console.log('Syntax check passed');
@@ -17,3 +19,22 @@ try {
   console.error('Syntax error in script:', err.message);
   process.exit(1);
 }
+
+// Data module tests
+await clearItems();
+await saveItems([
+  { id: '1', title: 'Test', content: 'Body', source: 'unit', timestamp: new Date().toISOString() }
+]);
+const items = await getAllItems();
+if (items.length !== 1 || items[0].title !== 'Test') {
+  console.error('IndexedDB storage test failed');
+  process.exit(1);
+}
+
+const norm = normalize({ title: 'A', content: 'B', source: 'S' });
+if (!norm.id || norm.title !== 'A' || !norm.timestamp) {
+  console.error('Normalization test failed');
+  process.exit(1);
+}
+
+console.log('Data module tests passed');


### PR DESCRIPTION
## Summary
- add data fetchers for RSS, news APIs, and uploads with normalization and IndexedDB storage
- wire refresh button to ingest data and repopulate feed
- convert project to ES modules and extend tests for data layer

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e95f529f88328b1696be644a7e114