### PR TITLE
Add visualization components with D3, Chart.js, and Leaflet

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,10 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Roboto+Mono:wght@500&display=swap" rel="stylesheet">
     <script src="https://unpkg.com/@phosphor-icons/web"></script>
+    <script src="https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
     <style>
         body {
             font-family: 'Inter', sans-serif;
@@ -420,5 +424,6 @@
         });
     });
     </script>
+    <script type="module" src="src/components/initVisualizations.js"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -9,5 +9,11 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs"
+  "type": "module",
+  "dependencies": {
+    "chart.js": "^4.4.0",
+    "d3": "^7.8.4",
+    "jsdom": "^23.0.0",
+    "leaflet": "^1.9.4"
+  }
 }

--- a/src/components/GeoMap.js
+++ b/src/components/GeoMap.js
@@ -1,0 +1,19 @@
+let Llib;
+if (typeof window === 'undefined') {
+  Llib = (await import('leaflet')).default;
+} else {
+  Llib = window.L;
+}
+const L = Llib;
+
+export function renderGeoMap(elementId, points) {
+  const map = L.map(elementId).setView([0, 0], 2);
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    maxZoom: 19,
+    attribution: '&copy; OpenStreetMap contributors'
+  }).addTo(map);
+  points.forEach(p => {
+    L.marker([p.lat, p.lng]).addTo(map).bindPopup(p.label || '');
+  });
+  return map;
+}

--- a/src/components/NetworkGraph.js
+++ b/src/components/NetworkGraph.js
@@ -1,0 +1,70 @@
+let d3Lib;
+if (typeof window === 'undefined') {
+  d3Lib = await import('d3');
+} else {
+  d3Lib = window.d3;
+}
+const d3 = d3Lib;
+
+export function renderNetworkGraph(data, selector) {
+  const width = 400;
+  const height = 300;
+  const container = typeof selector === 'string' ? d3.select(selector) : d3.select(selector);
+  const svg = container.append('svg').attr('width', width).attr('height', height);
+
+  const simulation = d3.forceSimulation(data.nodes)
+    .force('link', d3.forceLink(data.links).id(d => d.id).distance(80))
+    .force('charge', d3.forceManyBody().strength(-200))
+    .force('center', d3.forceCenter(width / 2, height / 2));
+
+  const link = svg.append('g')
+    .attr('stroke', '#999')
+    .selectAll('line')
+    .data(data.links)
+    .join('line');
+
+  const node = svg.append('g')
+    .attr('stroke', '#fff')
+    .attr('stroke-width', 1.5)
+    .selectAll('circle')
+    .data(data.nodes)
+    .join('circle')
+    .attr('r', 5)
+    .attr('fill', '#333')
+    .call(drag(simulation));
+
+  node.append('title').text(d => d.id);
+
+  simulation.on('tick', () => {
+    link
+      .attr('x1', d => d.source.x)
+      .attr('y1', d => d.source.y)
+      .attr('x2', d => d.target.x)
+      .attr('y2', d => d.target.y);
+
+    node
+      .attr('cx', d => d.x)
+      .attr('cy', d => d.y);
+  });
+}
+
+function drag(simulation) {
+  function dragstarted(event, d) {
+    if (!event.active) simulation.alphaTarget(0.3).restart();
+    d.fx = d.x;
+    d.fy = d.y;
+  }
+  function dragged(event, d) {
+    d.fx = event.x;
+    d.fy = event.y;
+  }
+  function dragended(event, d) {
+    if (!event.active) simulation.alphaTarget(0);
+    d.fx = null;
+    d.fy = null;
+  }
+  return d3.drag()
+    .on('start', dragstarted)
+    .on('drag', dragged)
+    .on('end', dragended);
+}

--- a/src/components/TimelineChart.js
+++ b/src/components/TimelineChart.js
@@ -1,0 +1,22 @@
+let ChartLib;
+if (typeof window === 'undefined') {
+  ChartLib = (await import('chart.js/auto')).Chart;
+} else {
+  ChartLib = window.Chart;
+}
+const Chart = ChartLib;
+
+export function renderTimelineChart(canvasId, dataset) {
+  const ctx = typeof canvasId === 'string' ? document.getElementById(canvasId) : canvasId;
+  return new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels: dataset.labels,
+      datasets: [{ label: 'Events', data: dataset.data, fill: false, borderColor: '#333' }]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false
+    }
+  });
+}

--- a/src/components/initVisualizations.js
+++ b/src/components/initVisualizations.js
@@ -1,0 +1,47 @@
+import { renderNetworkGraph } from './NetworkGraph.js';
+import { renderTimelineChart } from './TimelineChart.js';
+import { renderGeoMap } from './GeoMap.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const analysisPanel = document.getElementById('analysis-panel');
+  const container = document.createElement('div');
+  container.innerHTML = `
+    <div id="viz-tabs" class="flex gap-2 border-b-2 border-black p-2">
+      <button class="control-btn active" data-tab="graph">Network</button>
+      <button class="control-btn" data-tab="timeline">Timeline</button>
+      <button class="control-btn" data-tab="map">Map</button>
+    </div>
+    <div id="graph" class="h-64"></div>
+    <div id="timeline" class="h-64 hidden"><canvas id="timeline-canvas"></canvas></div>
+    <div id="map" class="h-64 hidden"></div>
+  `;
+  analysisPanel.appendChild(container);
+
+  renderNetworkGraph({
+    nodes: [{ id: 'A' }, { id: 'B' }, { id: 'C' }],
+    links: [
+      { source: 'A', target: 'B' },
+      { source: 'B', target: 'C' }
+    ]
+  }, '#graph');
+
+  renderTimelineChart('timeline-canvas', {
+    labels: ['Jan', 'Feb', 'Mar'],
+    data: [3, 5, 2]
+  });
+
+  renderGeoMap('map', [
+    { lat: 0, lng: 0, label: 'Null Island' },
+    { lat: 51.5, lng: -0.09, label: 'London' }
+  ]);
+
+  container.querySelectorAll('#viz-tabs button').forEach(btn => {
+    btn.addEventListener('click', () => {
+      container.querySelectorAll('#viz-tabs button').forEach(b => b.classList.remove('active'));
+      container.querySelectorAll('#graph, #timeline, #map').forEach(p => p.classList.add('hidden'));
+      btn.classList.add('active');
+      const target = btn.dataset.tab;
+      container.querySelector(`#${target}`).classList.remove('hidden');
+    });
+  });
+});

--- a/test.js
+++ b/test.js
@@ -1,19 +1,87 @@
-const fs = require('fs');
+import fs from 'fs';
 
+// Syntax check for inline scripts
 const html = fs.readFileSync('index.html', 'utf8');
-const scripts = [];
 const regex = /<script\b(?![^>]*\bsrc=)[^>]*>([\s\S]*?)<\/script>/gi;
 let match;
 while ((match = regex.exec(html)) !== null) {
-  scripts.push(match[1]);
+  try {
+    new Function(match[1]);
+  } catch (err) {
+    console.error('Syntax error in script:', err.message);
+    process.exit(1);
+  }
 }
 
+// Minimal DOM stubs
+global.window = {
+  document: {
+    elements: {},
+    createElement(tag) {
+      const el = { tagName: tag.toUpperCase(), style: {}, children: [], appendChild(child) { this.children.push(child); }, setAttribute() {} };
+      return el;
+    },
+    createElementNS(ns, tag) {
+      return this.createElement(tag);
+    },
+    getElementById(id) {
+      if (!this.elements[id]) {
+        this.elements[id] = { id, style: {}, children: [], appendChild(child) { this.children.push(child); }, setAttribute() {} };
+      }
+      return this.elements[id];
+    },
+    querySelector(sel) { return this.getElementById(sel.replace('#', '')); }
+  },
+  navigator: {}
+};
+
+global.document = global.window.document;
+
+global.window.HTMLCanvasElement = function () {};
+global.window.HTMLCanvasElement.prototype.getContext = () => ({});
+
+// Stub libraries
+function d3Obj() {
+  return {
+    append() { return d3Obj(); },
+    attr() { return this; },
+    selectAll() { return this; },
+    data() { return this; },
+    join() { return this; },
+    call() { return this; },
+    text() { return this; }
+  };
+}
+
+window.d3 = {
+  select() { return d3Obj(); },
+  forceSimulation() { return { force() { return this; }, on() {} }; },
+  forceLink() { return { id() { return this; }, distance() { return this; } }; },
+  forceManyBody() { return { strength() { return this; } }; },
+  forceCenter() { return {}; },
+  drag() { return { on() { return this; } }; }
+};
+
+window.Chart = class {
+  constructor() {}
+};
+
+window.L = {
+  map() { return { setView() { return this; } }; },
+  tileLayer() { return { addTo() { return this; } }; },
+  marker() { return { addTo() { return { bindPopup() {} }; } }; }
+};
+
+const { renderNetworkGraph } = await import('./src/components/NetworkGraph.js');
+const { renderTimelineChart } = await import('./src/components/TimelineChart.js');
+const { renderGeoMap } = await import('./src/components/GeoMap.js');
+
 try {
-  scripts.forEach((code, idx) => {
-    new Function(code);
-  });
-  console.log('Syntax check passed');
+  renderNetworkGraph({ nodes: [{ id: 'a' }, { id: 'b' }], links: [{ source: 'a', target: 'b' }] }, '#graph');
+  renderTimelineChart('timeline-canvas', { labels: ['Jan'], data: [1] });
+  renderGeoMap('map', [{ lat: 0, lng: 0, label: 'Origin' }]);
+  console.log('Visualization modules executed');
 } catch (err) {
-  console.error('Syntax error in script:', err.message);
+  console.error('Visualization test failed', err);
   process.exit(1);
 }


### PR DESCRIPTION
## Summary
- integrate D3-powered network graph renderer
- add timeline chart component using Chart.js
- display geocoded entities with Leaflet in analysis panel tabs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e95f8e4ac8328a2c04666ebddc762