### PR TITLE
Add dark mode toggle and accessibility enhancements

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,10 +14,18 @@
             color: #333333;
             overflow: hidden;
         }
+        .dark body {
+            background-color: #1F2937;
+            color: #F9FAFB;
+        }
 
         .brutalist-pane {
             background-color: #FFFFFF;
             border: 2px solid #333333;
+        }
+        .dark .brutalist-pane {
+            background-color: #374151;
+            border-color: #D1D5DB;
         }
         
         .priority-card {
@@ -32,6 +40,13 @@
             border-color: #333333 !important;
             border-left-width: 10px;
         }
+        .dark .priority-card:hover {
+            background: #1F2937;
+        }
+        .dark .priority-card.active {
+            background: #374151;
+            border-color: #F9FAFB !important;
+        }
         .priority-card.new-item {
             animation: highlight-new 2s ease-out;
         }
@@ -41,11 +56,11 @@
         }
 
         .loader {
-            border: 4px solid #e0e0e0; 
-            border-top: 4px solid #333333; 
+            border: 4px solid #e0e0e0;
+            border-top: 4px solid #333333;
             border-radius: 50%;
-            width: 40px; height: 40px; 
-            animation: spin 1s linear infinite; 
+            width: 40px; height: 40px;
+            animation: spin 1s linear infinite;
             margin: 2rem auto;
         }
         @keyframes spin { 0% { transform: rotate(0deg); } 100% { transform: rotate(360deg); } }
@@ -54,11 +69,16 @@
         ::-webkit-scrollbar-track { background: #F8F5F2; }
         ::-webkit-scrollbar-thumb { background-color: #D3CFCB; border: 2px solid #F8F5F2; border-radius: 5px;}
         ::-webkit-scrollbar-thumb:hover { background-color: #BFB9B3; }
+        .dark ::-webkit-scrollbar-track { background: #1F2937; }
+        .dark ::-webkit-scrollbar-thumb { background-color: #4B5563; border: 2px solid #1F2937; }
+        .dark ::-webkit-scrollbar-thumb:hover { background-color: #6B7280; }
 
         .mono-font { font-family: 'Roboto Mono', monospace; }
         
         .control-btn { background-color: #FFFFFF; border: 2px solid #e0e0e0; transition: all 0.2s ease; }
         .control-btn.active, .control-btn:hover { background-color: #333333; color: #FFFFFF; border-color: #333333; }
+        .dark .control-btn { background-color: #1F2937; border-color: #4B5563; color: #F9FAFB; }
+        .dark .control-btn.active, .dark .control-btn:hover { background-color: #F9FAFB; color: #1F2937; border-color: #F9FAFB; }
         
         .modal-overlay {
             position: fixed; inset: 0; background-color: rgba(0,0,0,0.5);
@@ -67,6 +87,14 @@
         }
         .modal-overlay.open { display: flex; }
         .modal-content { max-height: 85vh; }
+
+        .control-btn:focus-visible, .priority-card:focus-visible, .source-header:focus-visible {
+            outline: 2px solid #333333;
+            outline-offset: 2px;
+        }
+        .dark .control-btn:focus-visible, .dark .priority-card:focus-visible, .dark .source-header:focus-visible {
+            outline-color: #F9FAFB;
+        }
     </style>
 </head>
 <body class="h-screen w-screen">
@@ -77,25 +105,28 @@
             <header class="mb-4 border-b-2 border-black pb-4 flex-shrink-0">
                 <div class="flex justify-between items-center">
                     <div>
-                        <h1 class="text-3xl font-bold text-black">Intelligence Briefing</h1>
-                        <p class="text-gray-600 mono-font text-sm">Curated analysis of global events.</p>
+                        <h1 class="text-3xl font-bold text-black dark:text-white">Intelligence Briefing</h1>
+                        <p class="text-gray-600 dark:text-gray-300 mono-font text-sm">Curated analysis of global events.</p>
                     </div>
-                    <button id="settings-btn" class="control-btn font-semibold p-2"><i class="ph ph-gear text-xl"></i></button>
+                    <div class="flex gap-2">
+                        <button id="theme-toggle" aria-label="Toggle dark mode" aria-pressed="false" class="control-btn font-semibold p-2"><i class="ph ph-moon text-xl"></i></button>
+                        <button id="settings-btn" aria-label="Open settings" class="control-btn font-semibold p-2"><i class="ph ph-gear text-xl"></i></button>
+                    </div>
                 </div>
-                
+
                 <div class="mt-4 flex gap-2">
-                    <input id="rfi-search-input" type="text" placeholder="Request for Information (e.g., 'AUKUS pillar 2 status')" class="brutalist-pane w-full p-2 mono-font text-sm focus:outline-none focus:border-black">
-                    <button id="rfi-search-btn" class="control-btn font-semibold py-1 px-3"><i class="ph ph-magnifying-glass"></i></button>
+                    <input id="rfi-search-input" aria-label="Request for information input" type="text" placeholder="Request for Information (e.g., 'AUKUS pillar 2 status')" class="brutalist-pane w-full p-2 mono-font text-sm focus:outline-none focus:border-black">
+                    <button id="rfi-search-btn" aria-label="Submit RFI search" class="control-btn font-semibold py-1 px-3"><i class="ph ph-magnifying-glass"></i></button>
                 </div>
             </header>
-            
+
             <div class="mb-4 flex items-center justify-between flex-shrink-0">
-                <div id="filter-controls" class="flex items-center gap-2">
+                <div id="filter-controls" class="flex items-center gap-2" role="tablist">
                     <span class="text-sm font-semibold mono-font mr-2">SORT BY:</span>
-                    <button class="control-btn active font-semibold py-1 px-3" data-sort="relevance">Most Relevant</button>
-                    <button class="control-btn font-semibold py-1 px-3" data-sort="time">Latest</button>
+                    <button class="control-btn active font-semibold py-1 px-3" role="tab" aria-selected="true" aria-label="Sort by relevance" data-sort="relevance">Most Relevant</button>
+                    <button class="control-btn font-semibold py-1 px-3" role="tab" aria-selected="false" aria-label="Sort by time" data-sort="time">Latest</button>
                 </div>
-                <button id="export-btn" class="control-btn font-semibold py-1 px-3 text-sm flex items-center gap-1"><i class="ph ph-download-simple"></i> Export SITREP</button>
+                <button id="export-btn" aria-label="Export situation report" class="control-btn font-semibold py-1 px-3 text-sm flex items-center gap-1"><i class="ph ph-download-simple"></i> Export SITREP</button>
             </div>
 
             <main id="priority-feed" class="flex-grow space-y-4 overflow-y-auto pr-2"></main>
@@ -116,7 +147,21 @@
         const rfiBtn = document.getElementById('rfi-search-btn');
         const exportBtn = document.getElementById('export-btn');
         const settingsBtn = document.getElementById('settings-btn');
+        const themeToggle = document.getElementById('theme-toggle');
         const modalContainer = document.getElementById('modal-container');
+
+        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        const storedTheme = localStorage.getItem('theme');
+        if (storedTheme === 'dark' || (!storedTheme && prefersDark)) {
+            document.documentElement.classList.add('dark');
+            themeToggle.setAttribute('aria-pressed', 'true');
+        }
+        themeToggle.addEventListener('click', () => {
+            document.documentElement.classList.toggle('dark');
+            const isDark = document.documentElement.classList.contains('dark');
+            themeToggle.setAttribute('aria-pressed', isDark);
+            localStorage.setItem('theme', isDark ? 'dark' : 'light');
+        });
 
         const intelCategories = {
             "Geopolitical Flashpoints": { color: "#D87C5A", icon: "ph-fire" },
@@ -166,6 +211,9 @@
                 const categoryInfo = intelCategories[article.category];
                 const card = document.createElement('div');
                 card.className = 'priority-card brutalist-pane p-4 cursor-pointer';
+                card.tabIndex = 0;
+                card.setAttribute('role', 'button');
+                card.setAttribute('aria-label', `View analysis for ${article.title}`);
                 if (article.isNew) {
                     card.classList.add('new-item');
                     setTimeout(() => card.classList.remove('new-item'), 2000);
@@ -181,6 +229,12 @@
                     card.classList.add('active');
                     renderAnalysis(article.id);
                 });
+                card.addEventListener('keydown', (e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        card.click();
+                    }
+                });
                 priorityFeed.appendChild(card);
             });
         }
@@ -190,6 +244,9 @@
                 const categoryInfo = intelCategories[article.category];
                 const card = document.createElement('div');
                 card.className = 'priority-card brutalist-pane p-4 cursor-pointer';
+                card.tabIndex = 0;
+                card.setAttribute('role', 'button');
+                card.setAttribute('aria-label', `View analysis for ${article.title}`);
                 card.style.borderColor = categoryInfo.color;
                 card.dataset.id = article.id;
                 const sourceText = article.isSynthesized ? `MULTIPLE SOURCES (${article.sources.length})` : `SOURCE: ${article.source}`;
@@ -199,6 +256,12 @@
                     document.querySelectorAll('.priority-card').forEach(c => c.classList.remove('active'));
                     card.classList.add('active');
                     renderAnalysis(article.id);
+                });
+                card.addEventListener('keydown', (e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        card.click();
+                    }
                 });
                 priorityFeed.appendChild(card);
             });
@@ -255,8 +318,8 @@
         function renderAnalysis(id) {
             const article = masterNewsData.find(a => a.id === parseInt(id));
             if (!article) return;
-            const tabs = `<button class="control-btn active font-semibold py-1 px-3 text-sm" data-tab="analysis">Deep Analysis</button><button class="control-btn font-semibold py-1 px-3 text-sm" data-tab="network">Network</button><button class="control-btn font-semibold py-1 px-3 text-sm" data-tab="sentiment">Sentiment</button>`;
-            analysisPanel.innerHTML = `<div class="p-6"><h2 class="text-xl font-bold text-black mb-4 mono-font">// ANALYSIS: ${article.title}</h2><div class="flex items-center gap-2 mb-4">${tabs}</div><div id="analysis-content" class="space-y-6"></div></div>`;
+            const tabs = `<button class="control-btn active font-semibold py-1 px-3 text-sm" role="tab" aria-selected="true" data-tab="analysis">Deep Analysis</button><button class="control-btn font-semibold py-1 px-3 text-sm" role="tab" aria-selected="false" data-tab="network">Network</button><button class="control-btn font-semibold py-1 px-3 text-sm" role="tab" aria-selected="false" data-tab="sentiment">Sentiment</button>`;
+            analysisPanel.innerHTML = `<div class="p-6"><h2 class="text-xl font-bold text-black mb-4 mono-font">// ANALYSIS: ${article.title}</h2><div class="flex items-center gap-2 mb-4" role="tablist">${tabs}</div><div id="analysis-content" class="space-y-6"></div></div>`;
             const analysisContent = document.getElementById('analysis-content');
             function switchTab(tabName) {
                 if (tabName === 'analysis') getAnalysis(article, analysisContent);
@@ -266,9 +329,19 @@
             const tabButtons = analysisPanel.querySelectorAll('.control-btn[data-tab]');
             tabButtons.forEach(btn => {
                 btn.addEventListener('click', () => {
-                    tabButtons.forEach(b => b.classList.remove('active'));
+                    tabButtons.forEach(b => {
+                        b.classList.remove('active');
+                        b.setAttribute('aria-selected', 'false');
+                    });
                     btn.classList.add('active');
+                    btn.setAttribute('aria-selected', 'true');
                     switchTab(btn.dataset.tab);
+                });
+                btn.addEventListener('keydown', (e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        btn.click();
+                    }
                 });
             });
             switchTab('analysis');
@@ -313,7 +386,7 @@
             let sourceHtml = `<div class="mb-6"><h4 class="text-lg font-bold text-black mb-2 mono-font">Source Report(s)</h4><div id="source-list" class="space-y-3 bg-gray-50 p-3 border-2 border-gray-200">`;
             const sources = article.isSynthesized ? article.sources : [{ name: article.source, snippet: article.snippet, fullText: article.fullText }];
             sources.forEach((source, index) => {
-                sourceHtml += `<div class="source-item border-b border-gray-200 pb-2"><div class="source-header flex justify-between items-center cursor-pointer p-1"><p class="font-semibold mono-font text-sm">${source.name}</p><i class="ph ph-caret-down caret-icon"></i></div><div class="source-content pl-1"><p class="text-sm text-gray-700">${source.fullText || source.snippet}</p></div></div>`;
+                sourceHtml += `<div class="source-item border-b border-gray-200 pb-2"><div class="source-header flex justify-between items-center cursor-pointer p-1" tabindex="0" role="button" aria-expanded="false" aria-label="Toggle source details"><p class="font-semibold mono-font text-sm">${source.name}</p><i class="ph ph-caret-down caret-icon"></i></div><div class="source-content pl-1"><p class="text-sm text-gray-700 dark:text-gray-300">${source.fullText || source.snippet}</p></div></div>`;
             });
             sourceHtml += `</div></div>`;
             try {
@@ -344,8 +417,16 @@
                         header.addEventListener('click', () => {
                             const content = header.nextElementSibling;
                             const icon = header.querySelector('.caret-icon');
+                            const expanded = header.getAttribute('aria-expanded') === 'true';
+                            header.setAttribute('aria-expanded', String(!expanded));
                             content.classList.toggle('open');
                             icon.classList.toggle('open');
+                        });
+                        header.addEventListener('keydown', (e) => {
+                            if (e.key === 'Enter' || e.key === ' ') {
+                                e.preventDefault();
+                                header.click();
+                            }
                         });
                     });
                 } else { throw new Error("No content from AI."); }
@@ -353,7 +434,7 @@
         }
         
         function openModal(title, bodyHtml) {
-            modalContainer.innerHTML = `<div id="report-modal" class="modal-overlay open"><div class="brutalist-pane w-full max-w-4xl p-6 modal-content flex flex-col bg-white"><div class="flex justify-between items-center border-b-2 border-black pb-2 mb-4"><h2 class="text-xl font-bold mono-font">${title}</h2><button id="close-modal-btn" class="control-btn font-bold w-8 h-8">&times;</button></div><div id="modal-body" class="overflow-y-auto">${bodyHtml}</div></div></div>`;
+            modalContainer.innerHTML = `<div id="report-modal" class="modal-overlay open" role="dialog" aria-modal="true"><div class="brutalist-pane w-full max-w-4xl p-6 modal-content flex flex-col bg-white dark:bg-gray-800"><div class="flex justify-between items-center border-b-2 border-black pb-2 mb-4"><h2 class="text-xl font-bold mono-font">${title}</h2><button id="close-modal-btn" aria-label="Close modal" class="control-btn font-bold w-8 h-8">&times;</button></div><div id="modal-body" class="overflow-y-auto">${bodyHtml}</div></div></div>`;
             document.getElementById('close-modal-btn').addEventListener('click', () => modalContainer.innerHTML = '');
         }
 
@@ -391,8 +472,12 @@
 
         filterControls.addEventListener('click', (e) => {
             if (e.target.tagName === 'BUTTON') {
-                document.querySelectorAll('.control-btn').forEach(btn => btn.classList.remove('active'));
+                filterControls.querySelectorAll('[role="tab"]').forEach(btn => {
+                    btn.classList.remove('active');
+                    btn.setAttribute('aria-selected', 'false');
+                });
                 e.target.classList.add('active');
+                e.target.setAttribute('aria-selected', 'true');
                 renderPriorityFeed(e.target.dataset.sort);
             }
         });
@@ -401,6 +486,44 @@
         rfiInput.addEventListener('keypress', (e) => { if (e.key === 'Enter') handleRfiSearch(); });
         exportBtn.addEventListener('click', handleExport);
         settingsBtn.addEventListener('click', handleSettings);
+
+        document.addEventListener('keydown', (e) => {
+            if (e.key === '/' && document.activeElement !== rfiInput) {
+                e.preventDefault();
+                rfiInput.focus();
+            }
+            if (e.ctrlKey && e.key === ',') {
+                e.preventDefault();
+                handleSettings();
+            }
+            if (e.ctrlKey && e.key === 'e') {
+                e.preventDefault();
+                handleExport();
+            }
+            if (e.altKey && e.key === '1') {
+                e.preventDefault();
+                filterControls.querySelector('[data-sort="relevance"]').click();
+            }
+            if (e.altKey && e.key === '2') {
+                e.preventDefault();
+                filterControls.querySelector('[data-sort="time"]').click();
+            }
+            if (e.ctrlKey && e.key === '1') {
+                e.preventDefault();
+                const btn = analysisPanel.querySelector('[data-tab="analysis"]');
+                if (btn) btn.click();
+            }
+            if (e.ctrlKey && e.key === '2') {
+                e.preventDefault();
+                const btn = analysisPanel.querySelector('[data-tab="network"]');
+                if (btn) btn.click();
+            }
+            if (e.ctrlKey && e.key === '3') {
+                e.preventDefault();
+                const btn = analysisPanel.querySelector('[data-tab="sentiment"]');
+                if (btn) btn.click();
+            }
+        });
 
         // Initial Load
         displayedArticles = masterNewsData.slice(0, articlesPerPage);

--- a/test.js
+++ b/test.js
@@ -17,3 +17,20 @@ try {
   console.error('Syntax error in script:', err.message);
   process.exit(1);
 }
+
+function assert(condition, message) {
+  if (!condition) {
+    console.error(message);
+    process.exit(1);
+  }
+}
+
+['settings-btn', 'rfi-search-input', 'rfi-search-btn', 'export-btn', 'theme-toggle'].forEach(id => {
+  assert(new RegExp(`<[^>]*id="${id}"[^>]*aria-label=`, 'i').test(html), `Element #${id} missing aria-label`);
+});
+
+assert(/id="theme-toggle"/.test(html), 'Missing theme toggle button');
+assert(/card\.tabIndex\s*=\s*0/.test(html), 'Priority cards missing tabIndex assignment');
+assert(/source-header[^\n]*tabindex="0"/.test(html), 'Source headers missing tabindex');
+
+console.log('Accessibility checks passed');


### PR DESCRIPTION
## Summary
- add Tailwind-powered dark mode toggle with `prefers-color-scheme` fallback and persistence
- improve accessibility with ARIA labels, roles, focus styles, and keyboard navigation
- introduce keyboard shortcuts for search, settings, export, sorting, and analysis tabs
- extend tests to verify accessibility attributes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e95fb54008328ab6c27b9c9abefef