### PR TITLE
test: add jest and playwright setup with CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npx playwright install --with-deps
+      - run: npm run lint
+      - run: npm test
+      - run: npm run test:e2e

--- a/__tests__/analysis.test.js
+++ b/__tests__/analysis.test.js
@@ -1,0 +1,5 @@
+const { analyze } = require('../analysis');
+
+test('analyzes sum correctly', () => {
+  expect(analyze([1, 2, 3])).toBe(6);
+});

--- a/__tests__/dataFetcher.test.js
+++ b/__tests__/dataFetcher.test.js
@@ -1,0 +1,5 @@
+const { fetchData } = require('../dataFetcher');
+
+test('fetchData resolves with value', async () => {
+  await expect(fetchData()).resolves.toEqual({ value: 42 });
+});

--- a/analysis.js
+++ b/analysis.js
@@ -1,0 +1,4 @@
+function analyze(numbers) {
+  return numbers.reduce((sum, n) => sum + n, 0);
+}
+module.exports = { analyze };

--- a/dataFetcher.js
+++ b/dataFetcher.js
@@ -1,0 +1,4 @@
+async function fetchData() {
+  return { value: 42 };
+}
+module.exports = { fetchData };

--- a/e2e/basic.spec.js
+++ b/e2e/basic.spec.js
@@ -1,0 +1,8 @@
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+
+test('index loads with correct title', async ({ page }) => {
+  const filePath = 'file://' + path.resolve(__dirname, '..', 'index.html');
+  await page.goto(filePath);
+  await expect(page).toHaveTitle('Automated Intelligence Briefing');
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,18 @@
+module.exports = [
+  {
+    files: ['**/*.js'],
+    languageOptions: {
+      ecmaVersion: 2021,
+      sourceType: 'commonjs',
+      globals: {
+        console: 'readonly',
+        module: 'readonly',
+        require: 'readonly',
+        __dirname: 'readonly',
+        test: 'readonly',
+        expect: 'readonly',
+      },
+    },
+    rules: {},
+  },
+];

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "node test.js"
+    "lint": "eslint .",
+    "test": "jest",
+    "test:e2e": "playwright test"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- set up basic analysis and data fetching modules with Jest unit tests
- add Playwright UI test and ESLint flat config
- run lint and tests in GitHub Actions workflow

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*
- `npm run test:e2e` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e95fd03d88328927050a280b7a311