### PR TITLE
refactor: modularize layout components

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,43 +9,8 @@
     <link rel="stylesheet" href="dist/main.css">
 </head>
 <body class="h-screen w-screen">
-
-    <div class="flex h-full w-full gap-6 p-6">
-        <!-- Left Column: Priority Feed -->
-        <div class="w-1/2 flex flex-col h-full">
-            <header class="mb-4 border-b-2 border-black pb-4 flex-shrink-0">
-                <div class="flex justify-between items-center">
-                    <div>
-                        <h1 class="text-3xl font-bold text-black">Intelligence Briefing</h1>
-                        <p class="text-gray-600 mono-font text-sm">Curated analysis of global events.</p>
-                    </div>
-                    <button id="settings-btn" class="control-btn font-semibold p-2"><i class="ph ph-gear text-xl"></i></button>
-                </div>
-
-                <div class="mt-4 flex gap-2">
-                    <input id="rfi-search-input" type="text" placeholder="Request for Information (e.g., 'AUKUS pillar 2 status')" class="brutalist-pane w-full p-2 mono-font text-sm focus:outline-none focus:border-black">
-                    <button id="rfi-search-btn" class="control-btn font-semibold py-1 px-3"><i class="ph ph-magnifying-glass"></i></button>
-                </div>
-            </header>
-
-            <div class="mb-4 flex items-center justify-between flex-shrink-0">
-                <div id="filter-controls" class="flex items-center gap-2">
-                    <span class="text-sm font-semibold mono-font mr-2">SORT BY:</span>
-                    <button class="control-btn active font-semibold py-1 px-3" data-sort="relevance">Most Relevant</button>
-                    <button class="control-btn font-semibold py-1 px-3" data-sort="time">Latest</button>
-                </div>
-                <button id="export-btn" class="control-btn font-semibold py-1 px-3 text-sm flex items-center gap-1"><i class="ph ph-download-simple"></i> Export SITREP</button>
-            </div>
-
-            <main id="priority-feed" class="flex-grow space-y-4 overflow-y-auto pr-2"></main>
-        </div>
-
-        <!-- Right Column: Analysis Panel -->
-        <div id="analysis-panel" class="w-1/2 brutalist-pane flex flex-col h-full overflow-y-auto"></div>
-    </div>
-
+    <div id="app" class="flex h-full w-full gap-6 p-6"></div>
     <div id="modal-container"></div>
-
     <script type="module" src="dist/main.js"></script>
 </body>
 </html>

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   plugins: {
     tailwindcss: {},
     autoprefixer: {}

--- a/src/components/layout/AnalysisPanel.js
+++ b/src/components/layout/AnalysisPanel.js
@@ -1,0 +1,5 @@
+export function renderAnalysisPanel() {
+  return `
+    <div id="analysis-panel" class="w-1/2 brutalist-pane flex flex-col h-full overflow-y-auto"></div>
+  `;
+}

--- a/src/components/layout/Header.js
+++ b/src/components/layout/Header.js
@@ -1,0 +1,17 @@
+export function renderHeader() {
+  return `
+    <header class="mb-4 border-b-2 border-black pb-4 flex-shrink-0">
+      <div class="flex justify-between items-center">
+        <div>
+          <h1 class="text-3xl font-bold text-black">Intelligence Briefing</h1>
+          <p class="text-gray-600 mono-font text-sm">Curated analysis of global events.</p>
+        </div>
+        <button id="settings-btn" class="control-btn font-semibold p-2"><i class="ph ph-gear text-xl"></i></button>
+      </div>
+      <div class="mt-4 flex gap-2">
+        <input id="rfi-search-input" type="text" placeholder="Request for Information (e.g., 'AUKUS pillar 2 status')" class="brutalist-pane w-full p-2 mono-font text-sm focus:outline-none focus:border-black">
+        <button id="rfi-search-btn" class="control-btn font-semibold py-1 px-3"><i class="ph ph-magnifying-glass"></i></button>
+      </div>
+    </header>
+  `;
+}

--- a/src/components/layout/PriorityFeed.js
+++ b/src/components/layout/PriorityFeed.js
@@ -1,0 +1,13 @@
+export function renderPriorityFeed() {
+  return `
+    <div class="mb-4 flex items-center justify-between flex-shrink-0">
+      <div id="filter-controls" class="flex items-center gap-2">
+        <span class="text-sm font-semibold mono-font mr-2">SORT BY:</span>
+        <button class="control-btn active font-semibold py-1 px-3" data-sort="relevance">Most Relevant</button>
+        <button class="control-btn font-semibold py-1 px-3" data-sort="time">Latest</button>
+      </div>
+      <button id="export-btn" class="control-btn font-semibold py-1 px-3 text-sm flex items-center gap-1"><i class="ph ph-download-simple"></i> Export SITREP</button>
+    </div>
+    <main id="priority-feed" class="flex-grow space-y-4 overflow-y-auto pr-2"></main>
+  `;
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,20 @@
+import { renderHeader } from './components/layout/Header.js';
+import { renderPriorityFeed } from './components/layout/PriorityFeed.js';
+import { renderAnalysisPanel } from './components/layout/AnalysisPanel.js';
 import { initPriorityFeed } from './components/PriorityFeed.js';
 import { initAnalysisPanel } from './components/AnalysisPanel.js';
 
 document.addEventListener('DOMContentLoaded', () => {
+  const app = document.getElementById('app');
+  if (app) {
+    app.innerHTML = `
+      <div class="w-1/2 flex flex-col h-full">
+        ${renderHeader()}
+        ${renderPriorityFeed()}
+      </div>
+      ${renderAnalysisPanel()}
+    `;
+  }
   initPriorityFeed();
   initAnalysisPanel();
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,7 +5,12 @@ export default defineConfig({
   build: {
     outDir: 'dist',
     rollupOptions: {
-      input: './src/main.js'
+      input: {
+        main: './src/main.js',
+        header: './src/components/layout/Header.js',
+        priority: './src/components/layout/PriorityFeed.js',
+        analysis: './src/components/layout/AnalysisPanel.js'
+      }
     }
   }
 });


### PR DESCRIPTION
## Summary
- add layout components for header, priority feed, and analysis panel
- render layout components dynamically in main entry script
- bundle layout modules with updated Vite config
- convert PostCSS config to ESM for build

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e984d946c8328a332308825cd423c