### PR TITLE
Add data ingestion module and render feeds from sources

### DIFF
--- a/public/data/sample-items.json
+++ b/public/data/sample-items.json
@@ -1,0 +1,12 @@
+[
+  {
+    "title": "Sample File Item",
+    "url": "https://example.com/file1",
+    "date": "2024-01-01T00:00:00Z"
+  },
+  {
+    "headline": "Another Sample",
+    "link": "https://example.com/file2",
+    "pubDate": "2024-02-02T00:00:00Z"
+  }
+]

--- a/src/components/AnalysisPanel.js
+++ b/src/components/AnalysisPanel.js
@@ -1,6 +1,7 @@
-export function initAnalysisPanel() {
+export function initAnalysisPanel(items = []) {
   const panel = document.getElementById('analysis-panel');
   if (panel) {
-    panel.innerHTML = '<p class="text-gray-600">Analysis panel ready.</p>';
+    const sources = new Set(items.map(i => i.source));
+    panel.innerHTML = `<p class=\"text-gray-600\">Loaded ${items.length} items from ${sources.size} sources.</p>`;
   }
 }

--- a/src/components/PriorityFeed.js
+++ b/src/components/PriorityFeed.js
@@ -1,6 +1,11 @@
-export function initPriorityFeed() {
+export function initPriorityFeed(items = []) {
   const feed = document.getElementById('priority-feed');
   if (feed) {
-    feed.innerHTML = '<p class="text-gray-600">Priority feed loaded.</p>';
+    if (!items.length) {
+      feed.innerHTML = '<p class="text-gray-600">No items available.</p>';
+      return;
+    }
+    const list = items.map(item => `\n      <li class=\"mb-2\">\n        <a href=\"${item.url}\" class=\"text-blue-600\">${item.title}</a>\n        <span class=\"block text-xs text-gray-500\">${new Date(item.date).toLocaleString()} </span>\n      </li>`).join('');
+    feed.innerHTML = `<ul>${list}\n    </ul>`;
   }
 }

--- a/src/data/index.js
+++ b/src/data/index.js
@@ -1,0 +1,64 @@
+const isNode = typeof window === 'undefined';
+
+function normalizeItem(raw, source) {
+  return {
+    title: raw.title || raw.headline || 'Untitled',
+    url: raw.link || raw.url || '',
+    date: raw.pubDate || raw.date || new Date().toISOString(),
+    source
+  };
+}
+
+async function fetchRSS(url) {
+  const res = await fetch(url);
+  const text = await res.text();
+  const items = [];
+  const itemRegex = /<item>([\s\S]*?)<\/item>/g;
+  let match;
+  while ((match = itemRegex.exec(text)) !== null) {
+    const itemXML = match[1];
+    const titleMatch = /<title>(.*?)<\/title>/i.exec(itemXML);
+    const linkMatch = /<link>(.*?)<\/link>/i.exec(itemXML);
+    const dateMatch = /<pubDate>(.*?)<\/pubDate>/i.exec(itemXML);
+    items.push(normalizeItem({
+      title: titleMatch ? titleMatch[1] : 'Untitled',
+      link: linkMatch ? linkMatch[1] : '',
+      pubDate: dateMatch ? new Date(dateMatch[1]).toISOString() : new Date().toISOString()
+    }, url));
+  }
+  return items;
+}
+
+async function fetchAPI(url) {
+  const res = await fetch(url);
+  const data = await res.json();
+  const items = Array.isArray(data.items) ? data.items : Array.isArray(data) ? data : [];
+  return items.map(item => normalizeItem(item, url));
+}
+
+async function fetchFile(path) {
+  if (isNode) {
+    const fs = await import('fs/promises');
+    const text = await fs.readFile(path, 'utf-8');
+    const data = JSON.parse(text);
+    return Array.isArray(data) ? data.map(item => normalizeItem(item, path)) : [];
+  } else {
+    const res = await fetch(path);
+    const data = await res.json();
+    return Array.isArray(data) ? data.map(item => normalizeItem(item, path)) : [];
+  }
+}
+
+async function fetchFromSources(sources) {
+  const all = [];
+  for (const src of sources) {
+    let items = [];
+    if (src.type === 'rss') items = await fetchRSS(src.url);
+    else if (src.type === 'api') items = await fetchAPI(src.url);
+    else if (src.type === 'file') items = await fetchFile(src.path);
+    all.push(...items);
+  }
+  return all;
+}
+
+export { normalizeItem, fetchRSS, fetchAPI, fetchFile, fetchFromSources };

--- a/src/data/sampleConfig.js
+++ b/src/data/sampleConfig.js
@@ -1,0 +1,5 @@
+export const sources = [
+  { type: 'file', path: 'data/sample-items.json' },
+  { type: 'api', url: 'https://example.com/api/items' },
+  { type: 'rss', url: 'https://example.com/feed' }
+];

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,10 @@
 import { initPriorityFeed } from './components/PriorityFeed.js';
 import { initAnalysisPanel } from './components/AnalysisPanel.js';
+import { fetchFromSources } from './data/index.js';
+import { sources } from './data/sampleConfig.js';
 
-document.addEventListener('DOMContentLoaded', () => {
-  initPriorityFeed();
-  initAnalysisPanel();
+document.addEventListener('DOMContentLoaded', async () => {
+  const items = await fetchFromSources(sources);
+  initPriorityFeed(items);
+  initAnalysisPanel(items);
 });

--- a/test.js
+++ b/test.js
@@ -1,4 +1,5 @@
 import { readFileSync } from 'fs';
+import { normalizeItem, fetchFile } from './src/data/index.js';
 
 const html = readFileSync('index.html', 'utf8');
 
@@ -28,3 +29,21 @@ if (!distStyleRegex.test(html)) {
 }
 
 console.log('Index.html structure looks good');
+
+const rawItems = [
+  { title: 'A', link: 'http://a', pubDate: '2024-01-01T00:00:00Z' },
+  { headline: 'B', url: 'http://b', date: '2024-02-02T00:00:00Z' }
+];
+const normalized = rawItems.map(i => normalizeItem(i, 'test'));
+if (normalized[0].title !== 'A' || normalized[1].title !== 'B') {
+  console.error('Normalization failed');
+  process.exit(1);
+}
+console.log('Normalization works');
+
+const fileItems = await fetchFile('./public/data/sample-items.json');
+if (!Array.isArray(fileItems) || fileItems.length !== 2) {
+  console.error('File fetch failed');
+  process.exit(1);
+}
+console.log('File fetch works');


### PR DESCRIPTION
## Summary
- add `src/data` module with RSS, API, and file fetchers plus item normalization
- render Priority Feed and Analysis Panel from fetched items
- document sample data source configuration and file data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e98506d648328af35a340a3a57311