### PR TITLE
Add visualization components with mock data

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
   "author": "",
   "license": "ISC",
   "type": "module",
+  "dependencies": {
+    "chart.js": "^4.4.0",
+    "d3": "^7.8.5"
+  },
   "devDependencies": {
     "autoprefixer": "^10.4.14",
     "postcss": "^8.4.21",

--- a/src/components/AnalysisPanel.js
+++ b/src/components/AnalysisPanel.js
@@ -1,6 +1,21 @@
+import { renderNetworkGraph } from '../visualizations/networkGraph.js';
+import { renderSentimentTimeline } from '../visualizations/sentimentTimeline.js';
+import { networkData, sentimentData } from '../visualizations/fixtures.js';
+
 export function initAnalysisPanel() {
   const panel = document.getElementById('analysis-panel');
   if (panel) {
-    panel.innerHTML = '<p class="text-gray-600">Analysis panel ready.</p>';
+    panel.innerHTML = `
+      <div id="network-graph" class="mb-4"></div>
+      <canvas id="sentiment-timeline" height="200"></canvas>
+    `;
+
+    const networkEl = panel.querySelector('#network-graph');
+    renderNetworkGraph(networkEl, networkData);
+
+    const timelineCtx = panel
+      .querySelector('#sentiment-timeline')
+      .getContext('2d');
+    renderSentimentTimeline(timelineCtx, sentimentData);
   }
 }

--- a/src/visualizations/fixtures.js
+++ b/src/visualizations/fixtures.js
@@ -1,0 +1,17 @@
+export const networkData = {
+  nodes: [
+    { id: 'alpha' },
+    { id: 'bravo' },
+    { id: 'charlie' },
+  ],
+  links: [
+    { source: 'alpha', target: 'bravo' },
+    { source: 'bravo', target: 'charlie' },
+  ],
+};
+
+export const sentimentData = [
+  { date: '2024-01-01', sentiment: 0.2 },
+  { date: '2024-01-02', sentiment: -0.1 },
+  { date: '2024-01-03', sentiment: 0.4 },
+];

--- a/src/visualizations/networkGraph.js
+++ b/src/visualizations/networkGraph.js
@@ -1,0 +1,56 @@
+import * as d3 from 'd3';
+
+/**
+ * Render a simple force-directed network graph inside the given element.
+ * @param {HTMLElement} element - Container element where the graph will be rendered.
+ * @param {{nodes: Array, links: Array}} data - Graph data consisting of nodes and links.
+ */
+export function renderNetworkGraph(element, data) {
+  const width = 400;
+  const height = 300;
+
+  const svg = d3
+    .select(element)
+    .append('svg')
+    .attr('width', width)
+    .attr('height', height);
+
+  const simulation = d3
+    .forceSimulation(data.nodes)
+    .force(
+      'link',
+      d3.forceLink(data.links).id((d) => d.id).distance(50)
+    )
+    .force('charge', d3.forceManyBody().strength(-200))
+    .force('center', d3.forceCenter(width / 2, height / 2));
+
+  const link = svg
+    .append('g')
+    .attr('stroke', '#999')
+    .attr('stroke-opacity', 0.6)
+    .selectAll('line')
+    .data(data.links)
+    .enter()
+    .append('line');
+
+  const node = svg
+    .append('g')
+    .attr('stroke', '#fff')
+    .attr('stroke-width', 1.5)
+    .selectAll('circle')
+    .data(data.nodes)
+    .enter()
+    .append('circle')
+    .attr('r', 5)
+    .attr('fill', '#69b3a2');
+
+  simulation.on('tick', () => {
+    link
+      .attr('x1', (d) => d.source.x)
+      .attr('y1', (d) => d.source.y)
+      .attr('x2', (d) => d.target.x)
+      .attr('y2', (d) => d.target.y);
+
+    node.attr('cx', (d) => d.x).attr('cy', (d) => d.y);
+  });
+}

--- a/src/visualizations/sentimentTimeline.js
+++ b/src/visualizations/sentimentTimeline.js
@@ -1,0 +1,33 @@
+import Chart from 'chart.js/auto';
+
+/**
+ * Render a line chart showing sentiment over time.
+ * @param {CanvasRenderingContext2D} ctx - Canvas 2D context where chart will render.
+ * @param {Array<{date: string, sentiment: number}>} data - Sentiment data points.
+ */
+export function renderSentimentTimeline(ctx, data) {
+  return new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels: data.map((d) => d.date),
+      datasets: [
+        {
+          label: 'Sentiment',
+          data: data.map((d) => d.sentiment),
+          borderColor: 'rgb(75, 192, 192)',
+          tension: 0.1,
+          fill: false,
+        },
+      ],
+    },
+    options: {
+      responsive: true,
+      scales: {
+        y: {
+          min: -1,
+          max: 1,
+        },
+      },
+    },
+  });
+}

--- a/test.js
+++ b/test.js
@@ -1,4 +1,5 @@
 import { readFileSync } from 'fs';
+import { networkData, sentimentData } from './src/visualizations/fixtures.js';
 
 const html = readFileSync('index.html', 'utf8');
 
@@ -28,3 +29,20 @@ if (!distStyleRegex.test(html)) {
 }
 
 console.log('Index.html structure looks good');
+
+// Validate network graph data fixture
+if (!Array.isArray(networkData.nodes) || !Array.isArray(networkData.links)) {
+  console.error('Network data fixture is invalid');
+  process.exit(1);
+}
+
+// Validate sentiment timeline data fixture
+if (
+  !Array.isArray(sentimentData) ||
+  !sentimentData.every((d) => 'date' in d && 'sentiment' in d)
+) {
+  console.error('Sentiment data fixture is invalid');
+  process.exit(1);
+}
+
+console.log('Visualization data fixtures look good');


### PR DESCRIPTION
## Summary
- add Chart.js and D3 dependencies
- implement network graph and sentiment timeline components with mock fixtures
- integrate visualizations into analysis panel and add fixture tests

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/chart.js)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e9851b4b4832891237be4d0e4d6c7