### PR TITLE
feat: add settings modal with persistent preferences

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,26 @@
         <div id="analysis-panel" class="w-1/2 brutalist-pane flex flex-col h-full overflow-y-auto"></div>
     </div>
 
-    <div id="modal-container"></div>
+    <div id="modal-container" class="hidden fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+        <div class="brutalist-pane p-4 bg-white space-y-4">
+            <label class="block">
+                <span class="text-sm font-semibold">Auto-refresh interval (sec)</span>
+                <input id="auto-refresh" type="number" class="border p-1 w-full">
+            </label>
+            <label class="block">
+                <span class="text-sm font-semibold">Data source</span>
+                <select id="data-source" class="border p-1 w-full">
+                    <option value="default">Default</option>
+                    <option value="alt">Alternate</option>
+                </select>
+            </label>
+            <label class="block">
+                <span class="text-sm font-semibold">Analysis rules</span>
+                <textarea id="analysis-rules" class="border p-1 w-full"></textarea>
+            </label>
+            <button id="save-settings" class="control-btn font-semibold py-1 px-3">Save</button>
+        </div>
+    </div>
 
     <script type="module" src="dist/main.js"></script>
 </body>

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "node test.js"
+    "test": "node test.js && node --test tests/SettingsModal.test.js"
   },
   "keywords": [],
   "author": "",

--- a/src/components/SettingsModal.js
+++ b/src/components/SettingsModal.js
@@ -1,0 +1,64 @@
+const SETTINGS_KEY = 'settings';
+
+const defaultSettings = {
+  autoRefreshInterval: 30,
+  dataSource: 'default',
+  analysisRules: ''
+};
+
+export function loadSettings() {
+  try {
+    const stored = localStorage.getItem(SETTINGS_KEY);
+    return stored ? { ...defaultSettings, ...JSON.parse(stored) } : { ...defaultSettings };
+  } catch {
+    return { ...defaultSettings };
+  }
+}
+
+export function saveSettings(settings) {
+  localStorage.setItem(SETTINGS_KEY, JSON.stringify(settings));
+}
+
+export function initSettingsModal({
+  modal,
+  settingsButton,
+  autoRefreshInput,
+  dataSourceSelect,
+  analysisRulesTextarea,
+  saveButton
+}) {
+  const apply = () => {
+    const settings = loadSettings();
+    if (autoRefreshInput) {
+      autoRefreshInput.value = settings.autoRefreshInterval;
+    }
+    if (dataSourceSelect) {
+      dataSourceSelect.value = settings.dataSource;
+    }
+    if (analysisRulesTextarea) {
+      analysisRulesTextarea.value = settings.analysisRules;
+    }
+  };
+
+  if (settingsButton && modal) {
+    settingsButton.addEventListener('click', () => {
+      apply();
+      modal.classList.remove('hidden');
+    });
+  }
+
+  if (saveButton && modal) {
+    saveButton.addEventListener('click', () => {
+      const updated = {
+        autoRefreshInterval: parseInt(autoRefreshInput.value, 10),
+        dataSource: dataSourceSelect.value,
+        analysisRules: analysisRulesTextarea.value
+      };
+      saveSettings(updated);
+      modal.classList.add('hidden');
+    });
+  }
+
+  // apply settings to inputs on load
+  apply();
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,16 @@
 import { initPriorityFeed } from './components/PriorityFeed.js';
 import { initAnalysisPanel } from './components/AnalysisPanel.js';
+import { initSettingsModal } from './components/SettingsModal.js';
 
 document.addEventListener('DOMContentLoaded', () => {
   initPriorityFeed();
   initAnalysisPanel();
+  initSettingsModal({
+    modal: document.getElementById('modal-container'),
+    settingsButton: document.getElementById('settings-btn'),
+    autoRefreshInput: document.getElementById('auto-refresh'),
+    dataSourceSelect: document.getElementById('data-source'),
+    analysisRulesTextarea: document.getElementById('analysis-rules'),
+    saveButton: document.getElementById('save-settings')
+  });
 });

--- a/tests/SettingsModal.test.js
+++ b/tests/SettingsModal.test.js
@@ -1,0 +1,42 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { initSettingsModal } from '../src/components/SettingsModal.js';
+
+test('applies stored settings and persists changes', () => {
+  const storage = {};
+  global.localStorage = {
+    getItem: (key) => storage[key] || null,
+    setItem: (key, value) => { storage[key] = value; },
+    removeItem: (key) => { delete storage[key]; }
+  };
+
+  let saveHandler;
+  const elements = {
+    modal: { classList: { add: () => {}, remove: () => {} } },
+    settingsButton: { addEventListener: () => {} },
+    autoRefreshInput: { value: '', addEventListener: () => {} },
+    dataSourceSelect: { value: '', addEventListener: () => {} },
+    analysisRulesTextarea: { value: '', addEventListener: () => {} },
+    saveButton: { addEventListener: (event, cb) => { if (event === 'click') saveHandler = cb; } }
+  };
+
+  storage['settings'] = JSON.stringify({ autoRefreshInterval: 60, dataSource: 'alt', analysisRules: 'rule1' });
+
+  initSettingsModal(elements);
+
+  assert.equal(elements.autoRefreshInput.value, 60);
+  assert.equal(elements.dataSourceSelect.value, 'alt');
+  assert.equal(elements.analysisRulesTextarea.value, 'rule1');
+
+  elements.autoRefreshInput.value = 30;
+  elements.dataSourceSelect.value = 'default';
+  elements.analysisRulesTextarea.value = 'rule2';
+
+  saveHandler();
+
+  assert.deepStrictEqual(JSON.parse(storage['settings']), {
+    autoRefreshInterval: 30,
+    dataSource: 'default',
+    analysisRules: 'rule2'
+  });
+});


### PR DESCRIPTION
## Summary
- add SettingsModal component to handle auto-refresh, data source, and analysis rule preferences
- persist preferences in localStorage and surface modal in UI
- cover preference persistence with component test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e98538aec8328ad05703a2f1508d3