### PR TITLE
Add accessible dark mode toggle and keyboard shortcuts

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,22 +19,25 @@
                         <h1 class="text-3xl font-bold text-black">Intelligence Briefing</h1>
                         <p class="text-gray-600 mono-font text-sm">Curated analysis of global events.</p>
                     </div>
-                    <button id="settings-btn" class="control-btn font-semibold p-2"><i class="ph ph-gear text-xl"></i></button>
+                    <div class="flex gap-2">
+                        <button id="theme-toggle" class="control-btn font-semibold p-2" role="switch" aria-checked="false" aria-label="Toggle dark mode"><i class="ph ph-moon text-xl" aria-hidden="true"></i></button>
+                        <button id="settings-btn" class="control-btn font-semibold p-2" aria-label="Open settings"><i class="ph ph-gear text-xl" aria-hidden="true"></i></button>
+                    </div>
                 </div>
 
                 <div class="mt-4 flex gap-2">
-                    <input id="rfi-search-input" type="text" placeholder="Request for Information (e.g., 'AUKUS pillar 2 status')" class="brutalist-pane w-full p-2 mono-font text-sm focus:outline-none focus:border-black">
-                    <button id="rfi-search-btn" class="control-btn font-semibold py-1 px-3"><i class="ph ph-magnifying-glass"></i></button>
+                    <input id="rfi-search-input" type="text" placeholder="Request for Information (e.g., 'AUKUS pillar 2 status')" class="brutalist-pane w-full p-2 mono-font text-sm focus:outline-none focus:border-black" aria-label="Request for Information">
+                    <button id="rfi-search-btn" class="control-btn font-semibold py-1 px-3" aria-label="Search"><i class="ph ph-magnifying-glass" aria-hidden="true"></i></button>
                 </div>
             </header>
 
             <div class="mb-4 flex items-center justify-between flex-shrink-0">
                 <div id="filter-controls" class="flex items-center gap-2">
                     <span class="text-sm font-semibold mono-font mr-2">SORT BY:</span>
-                    <button class="control-btn active font-semibold py-1 px-3" data-sort="relevance">Most Relevant</button>
-                    <button class="control-btn font-semibold py-1 px-3" data-sort="time">Latest</button>
+                    <button class="control-btn active font-semibold py-1 px-3" data-sort="relevance" aria-label="Sort by relevance" aria-pressed="true">Most Relevant</button>
+                    <button class="control-btn font-semibold py-1 px-3" data-sort="time" aria-label="Sort by time" aria-pressed="false">Latest</button>
                 </div>
-                <button id="export-btn" class="control-btn font-semibold py-1 px-3 text-sm flex items-center gap-1"><i class="ph ph-download-simple"></i> Export SITREP</button>
+                <button id="export-btn" class="control-btn font-semibold py-1 px-3 text-sm flex items-center gap-1" aria-label="Export SITREP"><i class="ph ph-download-simple" aria-hidden="true"></i> Export SITREP</button>
             </div>
 
             <main id="priority-feed" class="flex-grow space-y-4 overflow-y-auto pr-2"></main>

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,69 @@
 import { initPriorityFeed } from './components/PriorityFeed.js';
 import { initAnalysisPanel } from './components/AnalysisPanel.js';
 
+function applyTheme(theme) {
+  const root = document.documentElement;
+  if (theme === 'dark') {
+    root.classList.add('dark');
+  } else {
+    root.classList.remove('dark');
+  }
+}
+
+function toggleTheme() {
+  const current = localStorage.getItem('theme') === 'dark' ? 'dark' : 'light';
+  const next = current === 'dark' ? 'light' : 'dark';
+  localStorage.setItem('theme', next);
+  applyTheme(next);
+  const toggle = document.getElementById('theme-toggle');
+  if (toggle) {
+    toggle.setAttribute('aria-checked', next === 'dark');
+  }
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   initPriorityFeed();
   initAnalysisPanel();
+
+  const storedTheme = localStorage.getItem('theme') || 'light';
+  applyTheme(storedTheme);
+
+  const themeToggle = document.getElementById('theme-toggle');
+  if (themeToggle) {
+    themeToggle.addEventListener('click', toggleTheme);
+    themeToggle.setAttribute('aria-checked', storedTheme === 'dark');
+  }
+
+  document.addEventListener('keydown', (e) => {
+    if (e.altKey) {
+      switch (e.key) {
+        case 's':
+          e.preventDefault();
+          document.getElementById('rfi-search-input')?.focus();
+          break;
+        case 'e':
+          e.preventDefault();
+          document.getElementById('export-btn')?.click();
+          break;
+        case 't':
+          e.preventDefault();
+          toggleTheme();
+          break;
+      }
+    }
+  });
+
+  const filterControls = document.getElementById('filter-controls');
+  if (filterControls) {
+    filterControls.addEventListener('click', (e) => {
+      const button = e.target.closest('button[data-sort]');
+      if (!button) return;
+      filterControls.querySelectorAll('button[data-sort]').forEach((btn) => {
+        btn.classList.remove('active');
+        btn.setAttribute('aria-pressed', 'false');
+      });
+      button.classList.add('active');
+      button.setAttribute('aria-pressed', 'true');
+    });
+  }
 });

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -9,9 +9,19 @@ body {
   overflow: hidden;
 }
 
+.dark body {
+  background-color: #1f2937;
+  color: #f3f4f6;
+}
+
 .brutalist-pane {
   background-color: #FFFFFF;
   border: 2px solid #333333;
+}
+
+.dark .brutalist-pane {
+  background-color: #374151;
+  border-color: #f3f4f6;
 }
 
 .priority-card {
@@ -21,10 +31,17 @@ body {
 .priority-card:hover {
   background: #F8F5F2;
 }
+.dark .priority-card:hover {
+  background: #374151;
+}
 .priority-card.active {
   background: #FFFFFF;
   border-color: #333333 !important;
   border-left-width: 10px;
+}
+.dark .priority-card.active {
+  background: #1f2937;
+  border-color: #f3f4f6 !important;
 }
 .priority-card.new-item {
   animation: highlight-new 2s ease-out;
@@ -49,10 +66,27 @@ body {
 ::-webkit-scrollbar-thumb { background-color: #D3CFCB; border: 2px solid #F8F5F2; border-radius: 5px; }
 ::-webkit-scrollbar-thumb:hover { background-color: #BFB9B3; }
 
+.dark ::-webkit-scrollbar-track { background: #1f2937; }
+.dark ::-webkit-scrollbar-thumb { background-color: #4b5563; border: 2px solid #1f2937; }
+.dark ::-webkit-scrollbar-thumb:hover { background-color: #6b7280; }
+
 .mono-font { font-family: 'Roboto Mono', monospace; }
 
 .control-btn { background-color: #FFFFFF; border: 2px solid #e0e0e0; transition: all 0.2s ease; }
 .control-btn.active, .control-btn:hover { background-color: #333333; color: #FFFFFF; border-color: #333333; }
+
+.dark .control-btn { background-color: #374151; border-color: #4b5563; color: #f3f4f6; }
+.dark .control-btn.active, .dark .control-btn:hover { background-color: #1f2937; color: #FFFFFF; border-color: #f3f4f6; }
+
+.control-btn:focus-visible,
+#rfi-search-input:focus-visible {
+  outline: 2px solid #333333;
+  outline-offset: 2px;
+}
+.dark .control-btn:focus-visible,
+.dark #rfi-search-input:focus-visible {
+  outline-color: #FFFFFF;
+}
 
 .modal-overlay {
   position: fixed; inset: 0; background-color: rgba(0,0,0,0.5);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  darkMode: 'class',
   content: ['./index.html', './src/**/*.{js,html}'],
   theme: {
     extend: {

--- a/test.js
+++ b/test.js
@@ -28,3 +28,20 @@ if (!distStyleRegex.test(html)) {
 }
 
 console.log('Index.html structure looks good');
+
+const requiredAria = ['settings-btn', 'theme-toggle', 'rfi-search-input', 'rfi-search-btn', 'export-btn'];
+for (const id of requiredAria) {
+  const pattern = new RegExp(`<[^>]*id="${id}"[^>]*aria-label=`, 'i');
+  if (!pattern.test(html)) {
+    console.error(`Accessibility: element #${id} missing aria-label`);
+    process.exit(1);
+  }
+}
+
+const filterButtons = html.match(/<button[^>]*data-sort="[^"]+"[^>]*>/gi) || [];
+if (filterButtons.some(btn => !/aria-pressed=/.test(btn))) {
+  console.error('Accessibility: sort buttons missing aria-pressed');
+  process.exit(1);
+}
+
+console.log('Accessibility checks passed');


### PR DESCRIPTION
## Summary
- add ARIA labels and theme toggle
- support dark mode styles and focus outlines
- add keyboard shortcuts and accessibility tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e9854fd808328a35fe30aba201373