### PR TITLE
Handle AI scoring failures with explicit fallback logging

### DIFF
--- a/src/analysis/dispatcher.js
+++ b/src/analysis/dispatcher.js
@@ -15,7 +15,11 @@ export async function scoreItem(item, { aiClient } = {}) {
       const aiScore = await aiClient.score(item);
       if (typeof aiScore === 'number') return aiScore;
     } catch (e) {
-      // fall back to rules
+      console.error('AI client failed, falling back to rule-based scoring:', e);
+      const fallbackScore = runRules(item);
+      const err = new Error('AI client failed');
+      err.fallbackScore = fallbackScore;
+      throw err;
     }
   }
   return runRules(item);

--- a/test.js
+++ b/test.js
@@ -1,2 +1,3 @@
 import './tests/index.test.js';
 import './tests/rules.test.js';
+import './tests/dispatcher.test.js';

--- a/tests/dispatcher.test.js
+++ b/tests/dispatcher.test.js
@@ -1,0 +1,31 @@
+import assert from 'assert';
+import { scoreItem } from '../src/analysis/dispatcher.js';
+
+const item = {
+  text: 'Urgent issue needs immediate attention',
+  metrics: { current: 200, average: 100 }
+};
+
+const failingClient = {
+  score: async () => { throw new Error('AI down'); }
+};
+
+const run = async () => {
+  let logged = false;
+  const originalError = console.error;
+  console.error = () => { logged = true; };
+
+  try {
+    await scoreItem(item, { aiClient: failingClient });
+    assert.fail('Expected scoreItem to throw');
+  } catch (err) {
+    assert(logged, 'Failure was not logged');
+    assert.strictEqual(err.fallbackScore, 2);
+  } finally {
+    console.error = originalError;
+  }
+
+  console.log('Dispatcher failure handling tests passed');
+};
+
+await run();

--- a/tests/rules.test.js
+++ b/tests/rules.test.js
@@ -18,8 +18,13 @@ const run = async () => {
 
   // dispatcher with failing AI client falls back to rules
   const failingClient = { score: async () => { throw new Error('AI down'); } };
-  const fallbackScore = await scoreItem(item, { aiClient: failingClient });
-  assert.strictEqual(fallbackScore, 2);
+  try {
+    await scoreItem(item, { aiClient: failingClient });
+    assert.fail('Expected scoreItem to throw');
+  } catch (err) {
+    assert.strictEqual(err.fallbackScore, 2);
+    assert.match(err.message, /AI client failed/);
+  }
 
   console.log('Rule tests passed');
 };


### PR DESCRIPTION
## Summary
- log AI client failures and expose fallback rule score
- add tests confirming logging and rule execution after AI failure

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e9acdabd48328b3f331a68fc7068f