### PR TITLE
refactor: dynamic layout imports

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,10 +1,13 @@
-import { renderHeader } from './components/layout/Header.js';
-import { renderPriorityFeed } from './components/layout/PriorityFeed.js';
-import { renderAnalysisPanel } from './components/layout/AnalysisPanel.js';
 import { initPriorityFeed } from './components/PriorityFeed.js';
 import { initAnalysisPanel } from './components/AnalysisPanel.js';
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
+  const [{ renderHeader }, { renderPriorityFeed }, { renderAnalysisPanel }] = await Promise.all([
+    import('./components/layout/Header.js'),
+    import('./components/layout/PriorityFeed.js'),
+    import('./components/layout/AnalysisPanel.js')
+  ]);
+
   const app = document.getElementById('app');
   if (app) {
     app.innerHTML = `

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,12 +5,7 @@ export default defineConfig({
   build: {
     outDir: 'dist',
     rollupOptions: {
-      input: {
-        main: './src/main.js',
-        header: './src/components/layout/Header.js',
-        priority: './src/components/layout/PriorityFeed.js',
-        analysis: './src/components/layout/AnalysisPanel.js'
-      }
+      input: 'src/main.js'
     }
   }
 });


### PR DESCRIPTION
## Summary
- simplify Vite build inputs to a single `src/main.js`
- dynamically import layout components in `main.js` for auto code splitting

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e9ad1060883289dab6c0dad4e8a7c