### PR TITLE
refactor: use lit-html for layout rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
   "author": "",
   "license": "ISC",
   "type": "module",
+  "dependencies": {
+    "lit-html": "^2.7.5"
+  },
   "devDependencies": {
     "autoprefixer": "^10.4.14",
     "postcss": "^8.4.21",

--- a/src/components/layout/AnalysisPanel.js
+++ b/src/components/layout/AnalysisPanel.js
@@ -1,5 +1,8 @@
+import { html } from 'lit-html';
+
 export function renderAnalysisPanel() {
-  return `
-    <div id="analysis-panel" class="w-1/2 brutalist-pane flex flex-col h-full overflow-y-auto"></div>
-  `;
+  return html`<div
+    id="analysis-panel"
+    class="w-1/2 brutalist-pane flex flex-col h-full overflow-y-auto"
+  ></div>`;
 }

--- a/src/components/layout/Header.js
+++ b/src/components/layout/Header.js
@@ -1,5 +1,7 @@
+import { html } from 'lit-html';
+
 export function renderHeader() {
-  return `
+  return html`
     <header class="mb-4 border-b-2 border-black pb-4 flex-shrink-0">
       <div class="flex justify-between items-center">
         <div>
@@ -9,7 +11,12 @@ export function renderHeader() {
         <button id="settings-btn" class="control-btn font-semibold p-2"><i class="ph ph-gear text-xl"></i></button>
       </div>
       <div class="mt-4 flex gap-2">
-        <input id="rfi-search-input" type="text" placeholder="Request for Information (e.g., 'AUKUS pillar 2 status')" class="brutalist-pane w-full p-2 mono-font text-sm focus:outline-none focus:border-black">
+        <input
+          id="rfi-search-input"
+          type="text"
+          placeholder="Request for Information (e.g., 'AUKUS pillar 2 status')"
+          class="brutalist-pane w-full p-2 mono-font text-sm focus:outline-none focus:border-black"
+        />
         <button id="rfi-search-btn" class="control-btn font-semibold py-1 px-3"><i class="ph ph-magnifying-glass"></i></button>
       </div>
     </header>

--- a/src/components/layout/PriorityFeed.js
+++ b/src/components/layout/PriorityFeed.js
@@ -1,12 +1,16 @@
+import { html } from 'lit-html';
+
 export function renderPriorityFeed() {
-  return `
+  return html`
     <div class="mb-4 flex items-center justify-between flex-shrink-0">
       <div id="filter-controls" class="flex items-center gap-2">
         <span class="text-sm font-semibold mono-font mr-2">SORT BY:</span>
         <button class="control-btn active font-semibold py-1 px-3" data-sort="relevance">Most Relevant</button>
         <button class="control-btn font-semibold py-1 px-3" data-sort="time">Latest</button>
       </div>
-      <button id="export-btn" class="control-btn font-semibold py-1 px-3 text-sm flex items-center gap-1"><i class="ph ph-download-simple"></i> Export SITREP</button>
+      <button id="export-btn" class="control-btn font-semibold py-1 px-3 text-sm flex items-center gap-1">
+        <i class="ph ph-download-simple"></i> Export SITREP
+      </button>
     </div>
     <main id="priority-feed" class="flex-grow space-y-4 overflow-y-auto pr-2"></main>
   `;

--- a/src/main.js
+++ b/src/main.js
@@ -1,3 +1,4 @@
+import { html, render } from 'lit-html';
 import { renderHeader } from './components/layout/Header.js';
 import { renderPriorityFeed } from './components/layout/PriorityFeed.js';
 import { renderAnalysisPanel } from './components/layout/AnalysisPanel.js';
@@ -7,13 +8,16 @@ import { initAnalysisPanel } from './components/AnalysisPanel.js';
 document.addEventListener('DOMContentLoaded', () => {
   const app = document.getElementById('app');
   if (app) {
-    app.innerHTML = `
-      <div class="w-1/2 flex flex-col h-full">
-        ${renderHeader()}
-        ${renderPriorityFeed()}
-      </div>
-      ${renderAnalysisPanel()}
-    `;
+    render(
+      html`
+        <div class="w-1/2 flex flex-col h-full">
+          ${renderHeader()}
+          ${renderPriorityFeed()}
+        </div>
+        ${renderAnalysisPanel()}
+      `,
+      app
+    );
   }
   initPriorityFeed();
   initAnalysisPanel();


### PR DESCRIPTION
## Summary
- adopt `lit-html` templating library
- refactor layout components to return `html` templates
- render layout via `lit-html` instead of string concatenation

## Testing
- `npm test`
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689e9ad1fe3c83288bb890ab517bf4c9